### PR TITLE
Small refactor of reference implementation

### DIFF
--- a/reference-implementation/index.js
+++ b/reference-implementation/index.js
@@ -2,7 +2,9 @@
 
 {
   const defineMath = (name, assignment) => {
-    const configurable = writable = enumerable = typeof assignment === "function";
+    const configurable = typeof assignment === "function";
+    const enumerable = configurable;
+    const writable = configurable;
 
     Object.defineProperty(Math, name, {
       configurable,

--- a/reference-implementation/index.js
+++ b/reference-implementation/index.js
@@ -3,13 +3,12 @@
 {
   const defineMath = (name, assignment) => {
     const configurable = typeof assignment === "function";
-    const enumerable = configurable;
     const writable = configurable;
 
     Object.defineProperty(Math, name, {
       configurable,
-      enumerable,
       writable,
+      enumerable: false,
       value: assignment
     });
   };

--- a/reference-implementation/index.js
+++ b/reference-implementation/index.js
@@ -2,14 +2,12 @@
 
 {
   const defineMath = (name, assignment) => {
-    var configurable = typeof assignment === "function" ? true : false;
-    var writable = typeof assignment === "function" ? true : false;
-    var enumerable = typeof assignment === "function" ? true : false;
+    const configurable = writable = enumerable = typeof assignment === "function";
 
     Object.defineProperty(Math, name, {
-      configurable: configurable,
-      enumerable: enumerable,
-      writable: writable,
+      configurable,
+      enumerable,
+      writable,
       value: assignment
     });
   };


### PR DESCRIPTION
Just curious why the code was *that* verbose.
~~I am not really a fan of the multiple assignments with the same value, but I did it either way.~~ and as expected they are bad

The main reason for this PR comes down to `true ? true : false`, kinda redundant imo